### PR TITLE
replace expanded dropdowns with collapsed

### DIFF
--- a/src/providers/ProjectsProvider.ts
+++ b/src/providers/ProjectsProvider.ts
@@ -1,7 +1,7 @@
 import * as vsc from 'vscode';
 
-import { ErrorEntry } from './entries/ErrorEntry';
 import { Entry } from './entries/Entry';
+import { ErrorEntry } from './entries/ErrorEntry';
 import { ProjectEntry } from './entries/ProjectEntry';
 import ProjectsState from '../state/ProjectsState';
 
@@ -62,7 +62,7 @@ export default class ProjectsProvider implements vsc.TreeDataProvider<Entry> {
             p.name === mainProject
               ? { label: p.name, highlights: [[0, p.name.length]] }
               : p.name,
-            vsc.TreeItemCollapsibleState.Expanded,
+            vsc.TreeItemCollapsibleState.Collapsed,
             p,
           ),
       ),

--- a/src/providers/entries/ProjectEntry.ts
+++ b/src/providers/entries/ProjectEntry.ts
@@ -1,7 +1,8 @@
 import * as vsc from 'vscode';
+
+import { ConfigGroupEntry } from './ConfigGroupEntry';
 import { DeveloperProject } from '../../contracts/projects';
 import { Entry } from './Entry';
-import { ConfigGroupEntry } from './ConfigGroupEntry';
 
 export class ProjectEntry extends Entry {
   constructor(
@@ -20,7 +21,7 @@ export class ProjectEntry extends Entry {
     return Promise.resolve([
       new ConfigGroupEntry(
         'Feature Gates',
-        vsc.TreeItemCollapsibleState.Expanded,
+        vsc.TreeItemCollapsibleState.Collapsed,
         this.data.feature_gates.map((c) => {
           return {
             projectID: this.data.id,
@@ -33,7 +34,7 @@ export class ProjectEntry extends Entry {
       ),
       new ConfigGroupEntry(
         'Dynamic Configs',
-        vsc.TreeItemCollapsibleState.Expanded,
+        vsc.TreeItemCollapsibleState.Collapsed,
         this.data.dynamic_configs.map((c) => {
           return {
             projectID: this.data.id,


### PR DESCRIPTION
# Summary
- collapses the dropdowns for the statsig projects and the subheadings (e.g. Feature Gates and Dynamic Configs)

# Testing
- figuring out how to test locally