### PR TITLE
fix: Support tsx files and fix output channel creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -260,5 +260,6 @@
   },
   "dependencies": {
     "axios": "^0.21.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,9 @@ import {
 } from './providers/ConfigCodeActionProvider';
 
 export function activate(context: vsc.ExtensionContext): void {
+  const outputChannel = vsc.window.createOutputChannel('Statsig output');
+  context.subscriptions.push(outputChannel);
+
   const config = getExtensionConfig();
   const projectsProvider = new ProjectsProvider(context);
   const statsigProjectsView = vsc.window.createTreeView('statsig.projects', {
@@ -91,7 +94,7 @@ export function activate(context: vsc.ExtensionContext): void {
       providedCodeActionKinds: ConfigCodeActionProvider.providedCodeActionKinds,
     },
   );
-  registerCommands(context);
+  registerCommands(context, outputChannel);
 
   void fetchConfigs.run({
     throttle: true,

--- a/src/lib/languageUtils.ts
+++ b/src/lib/languageUtils.ts
@@ -15,6 +15,7 @@ export type SupportedLanguageType = typeof SUPPORTED_LANGUAGES[number];
 export const SUPPORTED_FILE_EXTENSIONS = [
   'js',
   'ts',
+  'tsx',
   'py',
   'go',
   'rb',

--- a/src/providers/ConfigCodeActionProvider.ts
+++ b/src/providers/ConfigCodeActionProvider.ts
@@ -47,8 +47,8 @@ export class ConfigCodeActionProvider implements vsc.CodeActionProvider {
 
     const actions: vsc.CodeAction[] = [];
     context.diagnostics
-      .filter((diagnostic) => diagnostic.code === DiagnosticCode.staleCheck)
-      .forEach((diagnostic) => {
+      .filter((diagnostic: vsc.Diagnostic) => diagnostic.code === DiagnosticCode.staleCheck)
+      .forEach((diagnostic: vsc.Diagnostic) => {
         actions.push(
           this.newCodeAction(doc, range, diagnostic, {
             ...CODE_ACTIONS.removeStaleConfig,
@@ -197,8 +197,9 @@ const removeStaleConfigCommandHandler = (config: string, success: boolean) => {
   }
 };
 
-const removeAllStaleConfgsCommandHandler = async () => {
-  const output = vsc.window.createOutputChannel('Statsig output');
+const removeAllStaleConfgsCommandHandler = async (
+  output: vsc.OutputChannel,
+) => {
   const edit = new vsc.WorkspaceEdit();
   const files = await vsc.workspace.findFiles(
     `**/*.{${SUPPORTED_FILE_EXTENSIONS.join()}}`,
@@ -226,8 +227,8 @@ const removeAllStaleConfgsCommandHandler = async () => {
   output.appendLine('');
   output.appendLine('Summary of Instances Removed: ');
   Object.entries(configCounts)
-    .sort((a, b) => b[1] - a[1])
-    .forEach((counts) => {
+    .sort((a: [string, number], b: [string, number]) => b[1] - a[1])
+    .forEach((counts: [string, number]) => {
       output.appendLine(`${counts[0]}: ${counts[1]}`);
     });
   const success = await vsc.workspace.applyEdit(edit);
@@ -244,7 +245,10 @@ const removeAllStaleConfgsCommandHandler = async () => {
   }
 };
 
-export function registerCommands(context: vsc.ExtensionContext): void {
+export function registerCommands(
+  context: vsc.ExtensionContext,
+  output: vsc.OutputChannel,
+): void {
   context.subscriptions.push(
     vsc.commands.registerCommand(
       CODE_ACTIONS.removeStaleConfig.command,
@@ -252,7 +256,7 @@ export function registerCommands(context: vsc.ExtensionContext): void {
     ),
     vsc.commands.registerCommand(
       'statsig.cleanupStale',
-      removeAllStaleConfgsCommandHandler,
+      () => removeAllStaleConfgsCommandHandler(output),
     ),
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "es6",
     "outDir": "out",
-    "lib": ["es6"],
+    "lib": ["es2017"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Fix: Support .tsx files for cleanup and resolve duplicate output channels

**Problem:**

This PR addresses two issues in the VS Code extension:

1.  **Stale Gate/Config Cleanup Ignores .tsx Files:** The "Cleanup Stale Gates" (and related config cleanup) command failed to detect usage within `.tsx` files as this extension was not included in the list of file types to scan.
2.  **Duplicate Output Channels:** Running extension commands repeatedly created new, empty "Statsig output" channels in the Output panel instead of reusing the existing one. This prevented users from seeing command logs or error messages.

**Solution:**

1.  **Include .tsx Files:** Added `'tsx'` to the `SUPPORTED_FILE_EXTENSIONS` array in `src/lib/languageUtils.ts`. This ensures that TypeScript React files are correctly scanned for stale code.
2.  **Singleton Output Channel:** Refactored the output channel logic:
    *   The `vscode.OutputChannel` named "Statsig output" is now created only once during extension activation in `src/extension.ts`.
    *   This single instance is passed down and utilized by command handlers (e.g., in `src/providers/ConfigCodeActionProvider.ts`), preventing duplicate channel creation.

**Related Changes:**

*   Updated `tsconfig.json` to set `compilerOptions.lib` to `["es2017"]` to resolve TypeScript errors related to `Array.includes` and `Object.entries` that surfaced during the fix.
*   Added explicit type annotations where necessary to satisfy the linter.
*   Updated `yarn.lock`.

**Testing:**

* I need help testing this, not done any VSCode extensions in the past so unsure how to proceed. 